### PR TITLE
Various autocomplete improvements

### DIFF
--- a/src/autocomplete/autocomplete.ts
+++ b/src/autocomplete/autocomplete.ts
@@ -141,6 +141,7 @@ class SassCompletion implements CompletionItemProvider {
             );
             completionItem.detail = element.item.detail;
             completionItem.kind = element.item.kind;
+            completionItem.sortText = "6";
             variables.push(completionItem);
           }
         });
@@ -176,6 +177,7 @@ class SassCompletion implements CompletionItemProvider {
         completionItem.insertText = Utility.mergeNamespace(element.item.insert, namespace);
         completionItem.documentation = new MarkdownString(element.item.detail);
         completionItem.kind = element.item.kind;
+        completionItem.sortText = "1";
         variables.push(completionItem);
       }
     });

--- a/src/autocomplete/autocomplete.ts
+++ b/src/autocomplete/autocomplete.ts
@@ -63,6 +63,7 @@ class SassCompletion implements CompletionItemProvider {
     let classesAndIds = [];
     let functions = [];
     let variables: CompletionItem[] = [];
+    let htmlElements = [];
 
     let completions: CompletionItem[] = [];
     if (document.languageId === 'vue' || document.languageId === 'svelte') {
@@ -149,6 +150,7 @@ class SassCompletion implements CompletionItemProvider {
         classesAndIds = Utility.getHtmlClassOrIdCompletions(document);
         atRules = sassAt;
         properties = Utility.getProperties(currentWord);
+        htmlElements = Utility.getHtmlElements(currentWord);
       }
 
       completions = [].concat(
@@ -160,7 +162,8 @@ class SassCompletion implements CompletionItemProvider {
         atRules,
         classesAndIds,
         propertyScopedModules,
-        globalScopeModules
+        globalScopeModules,
+        htmlElements
       );
     }
 

--- a/src/autocomplete/autocomplete.utility.ts
+++ b/src/autocomplete/autocomplete.utility.ts
@@ -55,6 +55,7 @@ export class AutocompleteUtils {
     item.tags = prop.status === 'obsolete' ? [1] : [];
     item.documentation = GetPropertyDescription(prop.name, prop);
     item.kind = CompletionItemKind.Property;
+    item.sortText = "5";
     return item;
   }
 
@@ -71,6 +72,7 @@ export class AutocompleteUtils {
       const item = new CompletionItem(property.name);
       item.detail = property.desc;
       item.kind = CompletionItemKind.Value;
+      item.sortText = "3";
       return item;
     });
   }
@@ -154,6 +156,7 @@ export class AutocompleteUtils {
       completionItem.insertText = new SnippetString(rep + item.body);
       completionItem.detail = item.desc;
       completionItem.kind = CompletionItemKind.Unit;
+      completionItem.sortText = "1";
       units.push(completionItem);
     });
     return units;
@@ -176,12 +179,14 @@ export class AutocompleteUtils {
         item.insertText = rep;
         item.detail = `Import - ${rep}`;
         item.kind = CompletionItemKind.Reference;
+        item.sortText = "1";
         suggestions.push(item);
       } else if (statSync(path + '/' + file).isDirectory()) {
         const item = new CompletionItem(file);
         item.insertText = file;
         item.detail = `Folder - ${file}`;
         item.kind = CompletionItemKind.Folder;
+        item.sortText = "2";
         suggestions.push(item);
       }
     }
@@ -220,6 +225,7 @@ export class AutocompleteUtils {
                       item.kind = CompletionItemKind.Class;
                       item.detail = `Class From: ${fileName}`;
                       item.insertText = new SnippetString('.'.concat(className, '\n\t$0'));
+                      item.sortText = "7";
                       res.push(item);
                     }
                   }
@@ -230,6 +236,7 @@ export class AutocompleteUtils {
                   item.kind = CompletionItemKind.Class;
                   item.detail = `Id From: ${fileName}`;
                   item.insertText = new SnippetString('#'.concat(match, '\n\t$0'));
+                  item.sortText = "7";
                   res.push(item);
                 }
               }

--- a/src/autocomplete/autocomplete.utility.ts
+++ b/src/autocomplete/autocomplete.utility.ts
@@ -15,6 +15,7 @@ import { isClassOrId, isAtRule } from 'suf-regex';
 import { StateElement, State } from '../extension';
 import { getSassModule } from './schemas/autocomplete.builtInModules';
 import { generatedPropertyData } from './schemas/autocomplete.generatedData';
+import { positionValues, lineStyleValues, lineWidthValues, repeatValues } from './schemas/autocomplete.valueGroups';
 import { GetPropertyDescription } from '../utilityFunctions';
 
 export const importCssVariableRegex = /^[\t ]*\/\/[\t ]*import[\t ]*css-variables[\t ]*from/;
@@ -62,10 +63,31 @@ export class AutocompleteUtils {
   /** Returns values for current property for completion list */
   static getPropertyValues(currentWord: string): CompletionItem[] {
     const property = AutocompleteUtils.getPropertyName(currentWord);
-    const values = AutocompleteUtils.findPropertySchema(property)?.values;
-
-    if (!values) {
+    const schema = AutocompleteUtils.findPropertySchema(property);
+    if(!schema) {
       return [];
+    };
+
+    let values = [];
+
+    if (schema.values) {
+      values.push(...schema.values);
+    }
+
+    if(schema.restriction) {
+      const restrictions = schema.restriction.split(", ");
+      if(restrictions.includes("position")) {
+        values.push(...positionValues);
+      }
+      if(restrictions.includes("repeat")) {
+        values.push(...repeatValues);
+      }
+      if(restrictions.includes("line-style")) {
+        values.push(...lineStyleValues);
+      }
+      if(restrictions.includes("line-width")) {
+        values.push(...lineWidthValues);
+      }
     }
 
     return values.map((property) => {

--- a/src/autocomplete/autocomplete.utility.ts
+++ b/src/autocomplete/autocomplete.utility.ts
@@ -16,6 +16,7 @@ import { StateElement, State } from '../extension';
 import { getSassModule } from './schemas/autocomplete.builtInModules';
 import { generatedPropertyData } from './schemas/autocomplete.generatedData';
 import { positionValues, lineStyleValues, lineWidthValues, repeatValues } from './schemas/autocomplete.valueGroups';
+import { htmlTags } from './schemas/autocomplete.html';
 import { GetPropertyDescription } from '../utilityFunctions';
 
 export const importCssVariableRegex = /^[\t ]*\/\/[\t ]*import[\t ]*css-variables[\t ]*from/;
@@ -58,6 +59,18 @@ export class AutocompleteUtils {
     item.kind = CompletionItemKind.Property;
     item.sortText = "5";
     return item;
+  }
+
+  static getHtmlElements(currentWord: string): CompletionItem[] {
+    if (isClassOrId(currentWord) || isAtRule(currentWord)) {
+      return [];
+    }
+    return htmlTags.map((tagName) => {
+      const item = new CompletionItem(tagName);
+      item.kind = CompletionItemKind.Class;
+      item.sortText = "3";
+      return item;
+    });
   }
 
   /** Returns values for current property for completion list */

--- a/src/autocomplete/autocomplete.utility.ts
+++ b/src/autocomplete/autocomplete.utility.ts
@@ -79,7 +79,7 @@ export class AutocompleteUtils {
     const schema = AutocompleteUtils.findPropertySchema(property);
     if(!schema) {
       return [];
-    };
+    }
 
     let values = [];
 

--- a/src/autocomplete/schemas/autocomplete.at.ts
+++ b/src/autocomplete/schemas/autocomplete.at.ts
@@ -91,6 +91,7 @@ export const sassAt = sassAtArr.map((item) => {
   completionItem.insertText = new SnippetString(item.body);
   completionItem.detail = item.desc;
   completionItem.kind = CompletionItemKind.Function;
+  completionItem.sortText = "8";
 
   return completionItem;
 });

--- a/src/autocomplete/schemas/autocomplete.schema.ts
+++ b/src/autocomplete/schemas/autocomplete.schema.ts
@@ -309,5 +309,6 @@ export default sassSchema.map(item => {
   completionItem.insertText = new SnippetString(item.body);
   completionItem.detail = item.desc;
   completionItem.kind = CompletionItemKind.Function;
+  completionItem.sortText = "9";
   return completionItem;
 });

--- a/src/autocomplete/schemas/autocomplete.valueGroups.ts
+++ b/src/autocomplete/schemas/autocomplete.valueGroups.ts
@@ -1,0 +1,35 @@
+export const positionValues = [
+    {name: "bottom", desc: "Computes to ‘100%’ for the vertical position if one or two values are given, otherwise specifies the bottom edge as the origin for the next offset."},
+    {name: "center", desc: "Computes to ‘50%’ (‘left 50%’) for the horizontal position if the horizontal position is not otherwise specified, or ‘50%’ (‘top 50%’) for the vertical position if it is."},
+    {name: "left", desc: "Computes to ‘0%’ for the horizontal position if one or two values are given, otherwise specifies the left edge as the origin for the next offset."},
+    {name: "right", desc: "Computes to ‘100%’ for the horizontal position if one or two values are given, otherwise specifies the right edge as the origin for the next offset."},
+    {name: "top", desc: "Computes to ‘0%’ for the vertical position if one or two values are given, otherwise specifies the top edge as the origin for the next offset."},
+];
+
+export const repeatValues = [
+    {name: "no-repeat", desc: "Placed once and not repeated in this direction."},
+    {name: "repeat", desc: "Repeated in this direction as often as needed to cover the background painting area."},
+    {name: "repeat-x", desc: "Computes to ‘repeat no-repeat’."},
+    {name: "repeat-y", desc: "Computes to ‘no-repeat repeat’."},
+    {name: "round", desc: "Repeated as often as will fit within the background positioning area. If it doesn’t fit a whole number of times, it is rescaled so that it does."},
+    {name: "space", desc: "Repeated as often as will fit within the background positioning area without being clipped and then the images are spaced out to fill the area."},
+];
+
+export const lineStyleValues = [
+    {name: "dashed", desc: "A series of square-ended dashes."},
+    {name: "dotted", desc: "A series of round dots."},
+    {name: "double", desc: "Two parallel solid lines with some space between them."},
+    {name: "groove", desc: "Looks as if it were carved in the canvas."},
+    {name: "hidden", desc: "Same as ‘none’, but has different behavior in the border conflict resolution rules for border-collapsed tables."},
+    {name: "inset", desc: "Looks as if the content on the inside of the border is sunken into the canvas."},
+    {name: "none", desc: "No border. Color and width are ignored."},
+    {name: "outset", desc: "Looks as if the content on the inside of the border is coming out of the canvas."},
+    {name: "ridge", desc: "Looks as if it were coming out of the canvas."},
+    {name: "solid", desc: "A single line segment."},
+];
+
+export const lineWidthValues = [
+    {name: "medium"},
+    {name: "thick"},
+    {name: "thin"},
+];


### PR DESCRIPTION
- Sort autocomplete items by relevance (slightly subjective, but I hope the chosen order won't be controversial. Mainly it's about putting "global" completions last and promoting contextual ones)
- Autocomplete based on `"restriction"` field in `autocomplete.data.props.json`. This fixes value autocompletion for some properties, like `border-style`.
- Autocomplete HTML tags, mostly so that pressing enter after writing a tag doesn't complete a property instead.