### PR TITLE
Fix no suggestions bug when a directory is not open

### DIFF
--- a/src/autocomplete/search/autocomplete.search.ts
+++ b/src/autocomplete/search/autocomplete.search.ts
@@ -10,7 +10,7 @@ export class Searcher {
 
   /** searches for variables and mixin. */
   searchDocument(document: TextDocument) {
-    if (document.languageId === 'sass') {
+    if (document.languageId === 'sass' && workspace.workspaceFolders) {
       const text = document.getText();
 
       let workspacePath = '';


### PR DESCRIPTION
Fixed a bug that prevented any suggestions from working when a file was opened and edited by itself without a directory open.
The cause is that it references "workspace.workspaceFolders.length", so added a null check for "workspace.workspaceFolders".
Thank you.