### PR TITLE
Fix invalid regexes

### DIFF
--- a/syntaxes/sass.tmLanguage.json
+++ b/syntaxes/sass.tmLanguage.json
@@ -2,8 +2,8 @@
   "fileTypes": [
     "sass"
   ],
-  "foldingStartMarker": "/\\*|^#|^\\*|^\\b|*#?region|^\\.",
-  "foldingStopMarker": "\\*/|*#?endregion|^\\s*$",
+  "foldingStartMarker": "/\\*|^#|^\\*|^\\b|\\*#?region|^\\.",
+  "foldingStopMarker": "\\*/|\\*#?endregion|^\\s*$",
   "name": "Sass",
   "patterns": [
     {


### PR DESCRIPTION
The TM grammar for Sass includes two invalid Oniguruma regexes. Specifically, they include an unescaped `*` at the beginning of an alternation, which returns the Oniguruma error "target of repeat operator is not specified". Invalid regexes lead to the regexes failing silently in `vscode-textmate`.

Additionally, this makes the Sass grammar fail entirely when used with [Shiki](https://shiki.style/)'s JS engine (see Sass listed as unsupported in Shiki's JS engine [compatibility list](https://shiki.style/references/engine-js-compat)) because Shiki's JS engine doesn't fail silently for invalid Oniguruma regexes.

Since escaped versions (`\\*`) appear separately in preceding alternations in these same regexes, it looks like these `*` characters were meant to be escaped and match a literal `*`.