### PR TITLE
Fix import resolution issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,11 @@
             "nth-child"
           ],
           "description": "items in this array will be at the top of the completion list (only for items that show after the & sign)"
+        },
+        "sass.importRoot": {
+          "type": "string",
+          "default": "",
+          "description": "Root path used to look for Sass import files, used when comiling Sass with --load-path"
         }
       }
     },

--- a/src/autocomplete/search/autocomplete.search.ts
+++ b/src/autocomplete/search/autocomplete.search.ts
@@ -1,6 +1,7 @@
 import { State, StateItem, StateElement } from '../../extension';
 import { CompletionItemKind, ExtensionContext, TextDocument, workspace } from 'vscode';
 import { normalize, relative } from 'path';
+import { AutocompleteUtils } from '../autocomplete.utility';
 
 export class Searcher {
   context: ExtensionContext;
@@ -13,14 +14,7 @@ export class Searcher {
     if (document.languageId === 'sass' && workspace.workspaceFolders) {
       const text = document.getText();
 
-      let workspacePath = '';
-      for (let i = 0; i < workspace.workspaceFolders.length; i++) {
-        const path = workspace.workspaceFolders[i].uri.fsPath;
-        if (document.fileName.startsWith(path)) {
-          workspacePath = path;
-          break;
-        }
-      }
+      let workspacePath = AutocompleteUtils.getDocumentWorkspacePath(document);
 
       const pathBasename = relative(workspacePath, document.fileName);
 


### PR DESCRIPTION
- Allow a root path for Sass files to be imported from to match the behaviour of compiling Sass with --load_path
- Handle implict _ in filenames for partials